### PR TITLE
Message decoding task that requires the zoom-in tool use

### DIFF
--- a/src/r1_vlm/datasets/message_decoding_words/message_decoding_words_dataset.py
+++ b/src/r1_vlm/datasets/message_decoding_words/message_decoding_words_dataset.py
@@ -32,7 +32,7 @@ def get_font(size):
 
 
 def generate_decoder_image(
-    mapping, image_size=300, background_color="white", text_color="black"
+    mapping, image_size=300, background_color="white", text_color="black", random_size=False, max_font_size=20, min_font_size=3
 ):
     """
     Generates an image of the decoder, which is a 5x5 grid plus one extra mapping,
@@ -49,11 +49,16 @@ def generate_decoder_image(
     grid_width = image_size // 5  # 60px
     grid_height = (image_size - 50) // 5  # 50px (reserving 50px for bottom item)
 
-    # Start with a relatively small font size - we can adjust this
-    font = get_font(20)
 
     # Place first 25 mappings in the grid
     for idx in range(25):
+        # Determine the font and font size based on random_size
+        if random_size:
+            font_size = random.randint(min_font_size, max_font_size)
+        else:
+            font_size = max_font_size
+        font = get_font(font_size)
+
         row = idx // 5
         col = idx % 5
         source, target = mapping_items[idx]
@@ -68,8 +73,14 @@ def generate_decoder_image(
         text_height = bbox[3] - bbox[1]
 
         # Center text in cell
+        # If using random_size, we will also randomly shift the text in the cell, but making sure it's still inside the cell
         text_x = x - text_width // 2
         text_y = y - text_height // 2
+        if random_size:
+            x_shift = random.randint(-grid_width // 4, grid_width // 4)
+            y_shift = random.randint(-grid_height // 4, grid_height // 4)
+            text_x += x_shift
+            text_y += y_shift
 
         draw.text((text_x, text_y), mapping_text, fill=text_color, font=font)
 

--- a/src/r1_vlm/datasets/message_decoding_words/message_decoding_words_dataset.py
+++ b/src/r1_vlm/datasets/message_decoding_words/message_decoding_words_dataset.py
@@ -32,7 +32,7 @@ def get_font(size):
 
 
 def generate_decoder_image(
-    mapping, image_size=300, background_color="white", text_color="black", random_size=False, max_font_size=20, min_font_size=3
+    mapping, image_size=300, background_color="white", text_color="black"
 ):
     """
     Generates an image of the decoder, which is a 5x5 grid plus one extra mapping,
@@ -49,16 +49,11 @@ def generate_decoder_image(
     grid_width = image_size // 5  # 60px
     grid_height = (image_size - 50) // 5  # 50px (reserving 50px for bottom item)
 
+    # Start with a relatively small font size - we can adjust this
+    font = get_font(20)
 
     # Place first 25 mappings in the grid
     for idx in range(25):
-        # Determine the font and font size based on random_size
-        if random_size:
-            font_size = random.randint(min_font_size, max_font_size)
-        else:
-            font_size = max_font_size
-        font = get_font(font_size)
-
         row = idx // 5
         col = idx % 5
         source, target = mapping_items[idx]
@@ -73,14 +68,8 @@ def generate_decoder_image(
         text_height = bbox[3] - bbox[1]
 
         # Center text in cell
-        # If using random_size, we will also randomly shift the text in the cell, but making sure it's still inside the cell
         text_x = x - text_width // 2
         text_y = y - text_height // 2
-        if random_size:
-            x_shift = random.randint(-grid_width // 4, grid_width // 4)
-            y_shift = random.randint(-grid_height // 4, grid_height // 4)
-            text_x += x_shift
-            text_y += y_shift
 
         draw.text((text_x, text_y), mapping_text, fill=text_color, font=font)
 

--- a/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
+++ b/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
@@ -116,7 +116,7 @@ def zoom_in(full_coordinates, bbox, image_size=300) -> Image.Image:
     valid_full_coordinates = {k: v for k, v in full_coordinates.items() if v is not None}
     shorter_side = min(x2 - x1, y2 - y1)
     scale_factor = image_size / shorter_side
-    new_image_size = (int(shorter_side * scale_factor), int(shorter_side * scale_factor))
+    new_image_size = (int((x2 - x1) * scale_factor), int((y2 - y1) * scale_factor))
 
     # create the new image
     new_image = Image.new("RGB", new_image_size, "white")

--- a/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
+++ b/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
@@ -105,6 +105,36 @@ def generate_zoom_in_decoder_image(
     return image, full_coordinates
 
 
+def zoom_in(full_coordinates, bbox, image_size=300) -> Image.Image:
+    """
+    Given the full coordinates of the decoder image, and a bounding box representing the area of the image to zoom in on,
+    return the reconstructed zoomed-in image.
+    Since we want the zoomed-in image to be in high resolution, we need to build the image up from the full coordinates, rather than cropping the image.
+    """
+    # get the coordinates of the bounding box
+    x1, y1, x2, y2 = bbox
+    valid_full_coordinates = {k: v for k, v in full_coordinates.items() if v is not None}
+    shorter_side = min(x2 - x1, y2 - y1)
+    scale_factor = image_size / shorter_side
+    new_image_size = (int(shorter_side * scale_factor), int(shorter_side * scale_factor))
+
+    # create the new image
+    new_image = Image.new("RGB", new_image_size, "white")
+    draw = ImageDraw.Draw(new_image)
+    
+    # iterate over the valid full coordinates and draw them on the new image
+    # note that the positions and the font sizes are adjusted and scaled up by the scale factor
+    for mapping_text, (x, y, font_size) in valid_full_coordinates.items():
+        # adjust the position by the scale factor
+        new_x = int(x - x1) * scale_factor
+        new_y = int(y - y1) * scale_factor
+        new_font_size = int(font_size * scale_factor)
+        font = get_font(new_font_size)
+        draw.text((new_x, new_y), mapping_text, fill="black", font=font)
+
+    return new_image
+
+
 def create_sample(example):
     """
     Creates a sample for the message decoding dataset.

--- a/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
+++ b/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
@@ -20,7 +20,7 @@ def generate_zoom_in_decoder_image(
     background_color="white",
     text_color="black",
     max_font_size=20,
-    min_font_size=2,
+    min_font_size=4,
     font_size_variation=1,
     small_mappings_keys=[],
 ):
@@ -130,7 +130,7 @@ def create_sample(example):
         mapping=mapping,
         image_size=400,
         max_font_size=20,
-        min_font_size=2,
+        min_font_size=4,
         font_size_variation=1,
         small_mappings_keys=small_mappings_keys,
     )

--- a/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
+++ b/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
@@ -80,6 +80,12 @@ def generate_zoom_in_decoder_image(
 
     # Add the 26th mapping below the grid
     source, target = mapping_items[25]
+    if source in small_mapping_keys:
+        font_size = min_font_size + random.uniform(-font_size_variation, font_size_variation)
+    else:
+        font_size = max_font_size + random.uniform(-font_size_variation, font_size_variation)
+
+    font = get_font(font_size)
     bottom_text = f"{source}→{target}"
     bbox = draw.textbbox((0, 0), bottom_text, font=font)
     text_width = bbox[2] - bbox[0]
@@ -89,8 +95,13 @@ def generate_zoom_in_decoder_image(
     bottom_x = (image_size - text_width) // 2
     bottom_y = (5 * grid_height) + 10  # 10px padding after grid
 
-    draw.text((bottom_x, bottom_y), bottom_text, fill=text_color, font=font)
+    x_shift = random.randint(-grid_width // 4, grid_width // 4)
+    y_shift = random.randint(-grid_height // 4, grid_height // 4)
+    bottom_x += x_shift
+    bottom_y += y_shift
 
+    draw.text((bottom_x, bottom_y), bottom_text, fill=text_color, font=font)
+    full_coordinates[bottom_text] = (bottom_x, bottom_y, font_size)
     return image, full_coordinates
 
 

--- a/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
+++ b/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
@@ -96,7 +96,7 @@ def generate_zoom_in_decoder_image(
     bottom_y = (5 * grid_height) + 10  # 10px padding after grid
 
     x_shift = random.randint(-grid_width // 4, grid_width // 4)
-    y_shift = random.randint(-grid_height // 4, grid_height // 4)
+    y_shift = random.randint(-grid_height // 4, 0) # we don't want the bottom text to shift to the bottom further
     bottom_x += x_shift
     bottom_y += y_shift
 

--- a/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
+++ b/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
@@ -109,13 +109,6 @@ def create_sample(example):
     assert len(alphabet) == 26
     mapping = generate_mapping(alphabet)
 
-    # add a mapping for the underscore ("_") character. It will map to " " (space).
-    # This is so we can effectively communicate the space character in the coded message.
-    mapping["_"] = " "
-
-    # reverse the mapping to encode the message
-    reverse_mapping = {v: k for k, v in mapping.items()}
-
     positive_mappings = {k: v for k, v in mapping.items() if v in message.lower()} # mappings that should be used to decode the message
     negative_mappings = {k: v for k, v in mapping.items() if v not in message.lower()} # mappings that is irrelevant to the message
 
@@ -137,6 +130,12 @@ def create_sample(example):
         small_mappings_keys=small_mappings_keys,
     )
     
+    # add a mapping for the underscore ("_") character. It will map to " " (space).
+    # This is so we can effectively communicate the space character in the coded message.
+    mapping["_"] = " "
+
+    # reverse the mapping to encode the message
+    reverse_mapping = {v: k for k, v in mapping.items()}
 
     # create the coded and decoded message. If we encounter a character that is not in the mapping,
     # we will map it to itself.

--- a/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
+++ b/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
@@ -104,37 +104,6 @@ def generate_zoom_in_decoder_image(
     full_coordinates[bottom_text] = (bottom_x, bottom_y, font_size)
     return image, full_coordinates
 
-
-def zoom_in(full_coordinates, bbox, image_size=300) -> Image.Image:
-    """
-    Given the full coordinates of the decoder image, and a bounding box representing the area of the image to zoom in on,
-    return the reconstructed zoomed-in image.
-    Since we want the zoomed-in image to be in high resolution, we need to build the image up from the full coordinates, rather than cropping the image.
-    """
-    # get the coordinates of the bounding box
-    x1, y1, x2, y2 = bbox
-    valid_full_coordinates = {k: v for k, v in full_coordinates.items() if v is not None}
-    shorter_side = min(x2 - x1, y2 - y1)
-    scale_factor = image_size / shorter_side
-    new_image_size = (int((x2 - x1) * scale_factor), int((y2 - y1) * scale_factor))
-
-    # create the new image
-    new_image = Image.new("RGB", new_image_size, "white")
-    draw = ImageDraw.Draw(new_image)
-    
-    # iterate over the valid full coordinates and draw them on the new image
-    # note that the positions and the font sizes are adjusted and scaled up by the scale factor
-    for mapping_text, (x, y, font_size) in valid_full_coordinates.items():
-        # adjust the position by the scale factor
-        new_x = int(x - x1) * scale_factor
-        new_y = int(y - y1) * scale_factor
-        new_font_size = int(font_size * scale_factor)
-        font = get_font(new_font_size)
-        draw.text((new_x, new_y), mapping_text, fill="black", font=font)
-
-    return new_image
-
-
 def create_sample(example):
     """
     Creates a sample for the message decoding dataset.

--- a/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
+++ b/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in.py
@@ -116,6 +116,8 @@ def create_sample(example):
     # number of small positives: 80% of the time 1, 15% of the time 2, rest 3
     num_small_positives = random.choices([1, 2, 3], weights=[0.8, 0.15, 0.05])[0]
     num_small_negatives = 5 - num_small_positives
+    num_small_positives = min(num_small_positives, len(positive_mappings))
+    num_small_negatives = min(num_small_negatives, len(negative_mappings))
 
     # selecting the mappings that will be shown small on the decoder image
     small_mappings_keys = random.sample(list(positive_mappings.keys()), num_small_positives)
@@ -160,7 +162,7 @@ def create_sample(example):
         else:
             raise ValueError(f"Character {char} is not in the mapping")
 
-    return decoder_image, decoded_message, coded_message, mapping, num_small_positives, full_coordinates
+    return decoder_image, decoded_message, coded_message, mapping, num_small_positives, num_small_negatives, full_coordinates
 
 
 def create_dataset():
@@ -172,6 +174,7 @@ def create_dataset():
         "image": [],
         "task": [],
         "num_small_positives": [],
+        "num_small_negatives": [],
         "full_coordinates": [],
     }
 
@@ -212,6 +215,7 @@ def create_dataset():
         "image": [],
         "task": [],
         "num_small_positives": [],
+        "num_small_negatives": [],
         "full_coordinates": [],
     }
 
@@ -220,7 +224,7 @@ def create_dataset():
         text = example["text"]
         task = example["task"]
 
-        decoder_image, message, coded_message, mapping, num_small_positives, full_coordinates = create_sample(example)
+        decoder_image, message, coded_message, mapping, num_small_positives, num_small_negatives, full_coordinates = create_sample(example)
 
         fpath = f"images/{i}.png"
         full_path = image_dir / f"{i}.png"
@@ -241,6 +245,7 @@ def create_dataset():
         data["image"].append(decoder_image)
         data["task"].append(task)
         data["num_small_positives"].append(num_small_positives)
+        data["num_small_negatives"].append(num_small_negatives)
         data["full_coordinates"].append(full_coordinates)
     decoding_dataset = Dataset.from_dict(data)
 

--- a/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in_r1.py
+++ b/src/r1_vlm/datasets/message_decoding_words_and_sequences_zoom_in/message_decoding_words_and_sequences_zoom_in_r1.py
@@ -1,0 +1,110 @@
+import os
+
+from datasets import Dataset, DatasetDict, load_dataset
+from dotenv import find_dotenv, load_dotenv
+from tqdm import tqdm
+from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
+load_dotenv(dotenv_path=find_dotenv())
+
+
+def generate_r1_messages(example):
+    coded_message = example["coded_message"]
+    decoded_message = example["decoded_message"]
+    mapping = example["mapping"]
+    task = example["task"]
+    image = example["image"]
+    num_small_positives = example["num_small_positives"]
+    num_small_negatives = example["num_small_negatives"]
+    full_coordinates = example["full_coordinates"]
+    file_path = example["file_path"]
+
+    # add spaces between each character to prevent tokenization issues
+    coded_message = " ".join(coded_message)
+
+    instruction = (
+        "Use the decoder in the image to decode a coded message."
+        "The decoded message will be one or more words. Underscore characters "
+        '("_") in the coded message should be mapped to a space (" ") when decoding.'
+        "Show your work in <think> </think> tags and return the answer in <answer> </answer> tags. "
+        "While thinking, you must include a section with the decoded characters using <chars></chars> tags. "
+        "The <chars> section should include the decoded characters in the order they are decoded. It should include the "
+        "underscore character wherever there is a space in the decoded message. For example, if the coded message is "
+        "a b c _ d e f, the chars section might be <chars> c a t _ d o g </chars>. You can think about the problem for "
+        "as long as you'd like. While thinking, you should robustly verify your solution. Once you are done thinking, "
+        f"provide your answer in the <answer> section, e.g. <answer> cat dog </answer>. The coded message is: {coded_message}."
+    )
+
+    ending = (
+        "You are very bad at determining this directly from the image, because some key mappings in the decoder are too small to see."
+        "Instead, please use the tools available to you to solve this problem."
+    )
+    instruction = f"{instruction} {ending}"
+
+    r1_messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "REPLACED WITH TOOLS SYSTEM PROMPT",
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "<image_name> input_image </image_name>"},
+                {"type": "image", "image": IMAGE_PLACEHOLDER},
+                {"type": "text", "text": instruction},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "<think> Let me solve this step by step.\n"}
+            ],
+        },
+    ]
+
+    return {
+        "messages": r1_messages,
+        "coded_message": coded_message,
+        "decoded_message": decoded_message,
+        "mapping": mapping,
+        "file_path": file_path,
+        "image": image,
+        "task": task,
+        "num_small_positives": num_small_positives,
+        "num_small_negatives": num_small_negatives,
+        "full_coordinates": full_coordinates,
+    }
+
+
+def create_r1_message_decoding_dataset():
+    dataset = load_dataset(
+        "Groundlight/message-decoding-words-and-sequences-zoom-in", split="train"
+    )
+
+    examples = []
+    for example in tqdm(dataset, desc="Processing examples"):
+        processed_example = generate_r1_messages(example)
+        examples.append(processed_example)
+
+    processed_dataset = Dataset.from_list(examples)
+
+    splits = processed_dataset.train_test_split(test_size=0.1, seed=42)
+
+    dataset_dict = {
+        "train": splits["train"],
+        "test": splits["test"],
+    }
+
+    r1_dataset = DatasetDict(dataset_dict)
+    r1_dataset.push_to_hub(
+        "Groundlight/message-decoding-words-and-sequences-zoom-in-r1",
+        token=os.getenv("HUGGINGFACE_HUB_TOKEN"),
+    )
+
+
+if __name__ == "__main__":
+    create_r1_message_decoding_dataset()

--- a/src/r1_vlm/environments/message_decoding_zoom_in_env/message_decoding_zoom_in_env.py
+++ b/src/r1_vlm/environments/message_decoding_zoom_in_env/message_decoding_zoom_in_env.py
@@ -91,10 +91,13 @@ class MessageDecodingZoomInEnv(ToolVisionEnv):
                 print(f"Error in check_format: {e}")
                 return 0.0
 
-        def correctness_reward_func(completions, **kwargs) -> list[float]:
+        def correctness_reward_func(prompts, completions, completions_messages, **kwargs) -> list[float]:
             """Reward function that checks if the predicted answer matches the true answer. Only checks the last message in the completion."""
             # parse the predicted decoded message from each completion
-            responses = [self.llm_parser.parse(c[0]["content"]).answer for c in completions]
+
+            merged_completion_conversations = self.preprocess_messages(prompts_messages=prompts, completions_messages=completions_messages)
+            # parse the last message in each completion (completions are conversations) for data between <answer> and </answer> tags
+            responses = [self.llm_parser.parse(c[-1]["content"][0]["text"]).answer for c in merged_completion_conversations]
             true_decoded_messages = kwargs["decoded_message"]
 
             def check_answer(response, answer):

--- a/src/r1_vlm/environments/message_decoding_zoom_in_env/message_decoding_zoom_in_env.py
+++ b/src/r1_vlm/environments/message_decoding_zoom_in_env/message_decoding_zoom_in_env.py
@@ -1,0 +1,120 @@
+import re
+from statistics import mean
+from typing import Any, Callable
+
+from datasets import Dataset, concatenate_datasets, load_dataset
+from transformers import AutoProcessor
+from trl.trainer.grpo_trainer import RewardFunc
+
+from r1_vlm.datasets.utils import preprocess_r1_dataset
+from r1_vlm.environments.tool_vision_env import ToolVisionEnv
+from r1_vlm.tools.message_decoding_zoom_in_tool import zoom_in
+
+
+class MessageDecodingZoomInEnv(ToolVisionEnv):
+    def __init__(self,
+                 processing_class: AutoProcessor,
+                 dataset_name: str = "Groundlight/message-decoding-words-and-sequences-zoom-in",
+                #  tool that simulates zoom-in by reconstructing the zoomed-in image from the full coordinates of texts
+                 tools: list[Callable] = [zoom_in],
+                 max_steps: int = 10,
+                 **kwargs,
+                 ):
+
+        super().__init__(
+            tools=tools,
+            processing_class=processing_class,
+            max_steps=max_steps,
+        )
+        
+        self.dataset_name = dataset_name
+
+    def get_dataset(self) -> Dataset:
+        dataset = load_dataset(self.dataset_name)
+        dataset = dataset["train"]
+        dataset = self.inject_system_prompt(dataset)
+        dataset = preprocess_r1_dataset(dataset)
+        return dataset
+    
+    def get_assistant_messages(self, conversation: list[dict[str, Any]]) -> list[str]:
+        '''
+        Returns the assistant messages from the completion messages as a list of strings.
+        '''
+        assistant_messages = [message["content"][0]["text"] for message in conversation if message["role"] == "assistant"]
+        return assistant_messages
+    
+    def get_rubric(self) -> list[RewardFunc]:
+        
+        def format_reward_func(prompts, completions, completions_messages, **kwargs) -> list[float]:
+            '''
+            Returns the average compliance over all model messages in the completion.
+            
+            prompts: list of messages that make up the original prompt
+            completions: list of completion strings (not used, but required by the interface)
+            completions_messages: list of messages in the completion
+            '''
+            
+            merged_completion_conversations = self.preprocess_messages(prompts_messages=prompts, completions_messages=completions_messages)
+            
+            rewards = []
+            for conversation in merged_completion_conversations:
+                assistant_messages = self.get_assistant_messages(conversation)
+                
+                format_correct = [check_format(message) for message in assistant_messages]
+                format_correct = mean(format_correct)
+                rewards.append(format_correct)
+                
+            return rewards
+
+        def check_format(text: str) -> float:
+            '''
+            Checks if the format is correct for a single message.
+            '''
+            # Find and start from the first <think> tag (removes the bootstrap prompt, if it exists)
+            think_start = text.find("<think>")
+            if think_start != -1:
+                text = text[think_start:]
+
+            try:
+                # Check if the format is correct
+                answer_regex = r"^<think>([^<]*(?:<(?!/?think>)[^<]*)*)<\/think>\n<answer>([\s\S]*?)<\/answer>$"
+                tool_regex = r"^<think>([^<]*(?:<(?!/?think>)[^<]*)*)<\/think>\n<tool>([\s\S]*?)<\/tool>$"
+
+                answer_match = re.search(answer_regex, text, re.DOTALL)
+                tool_match = re.search(tool_regex, text, re.DOTALL)
+
+                if (answer_match is not None and len(answer_match.groups()) == 2) or \
+                   (tool_match is not None and len(tool_match.groups()) == 2):
+                    return 1.0
+                return 0.0
+            except Exception as e:
+                print(f"Error in check_format: {e}")
+                return 0.0
+
+        def correctness_reward_func(completions, **kwargs) -> list[float]:
+            """Reward function that checks if the predicted answer matches the true answer. Only checks the last message in the completion."""
+            # parse the predicted decoded message from each completion
+            responses = [self.llm_parser.parse(c[0]["content"]).answer for c in completions]
+            true_decoded_messages = kwargs["decoded_message"]
+
+            def check_answer(response, answer):
+                # the parser returns None if the answer is not found
+                if response is None:
+                    return 0.0
+
+                try:
+                    response = response.strip()
+                    answer = answer.strip()
+                except Exception as e:
+                    print(f"Error in check_answer for correctness: {e}")
+                    return 0.0
+
+                if response == answer:
+                    return 1.0
+                else:
+                    return 0.0
+            
+            answers_correct = [check_answer(r, t) for r, t in zip(responses, true_decoded_messages)]
+            return answers_correct
+        
+        return [format_reward_func, correctness_reward_func]

--- a/src/r1_vlm/environments/message_decoding_zoom_in_env/message_decoding_zoom_in_env.py
+++ b/src/r1_vlm/environments/message_decoding_zoom_in_env/message_decoding_zoom_in_env.py
@@ -14,7 +14,7 @@ from r1_vlm.tools.message_decoding_zoom_in_tool import zoom_in
 class MessageDecodingZoomInEnv(ToolVisionEnv):
     def __init__(self,
                  processing_class: AutoProcessor,
-                 dataset_name: str = "Groundlight/message-decoding-words-and-sequences-zoom-in",
+                 dataset_name: str = "Groundlight/message-decoding-words-and-sequences-zoom-in-r1",
                 #  tool that simulates zoom-in by reconstructing the zoomed-in image from the full coordinates of texts
                  tools: list[Callable] = [zoom_in],
                  max_steps: int = 10,

--- a/src/r1_vlm/environments/message_decoding_zoom_in_env/train.py
+++ b/src/r1_vlm/environments/message_decoding_zoom_in_env/train.py
@@ -16,7 +16,7 @@ os.environ["WANDB_PROJECT"] = "message-decoding-zoom-in"
 
 
 # Flag that determines if gradient checkpointing is used. If it is, we need to set use_cache to False.
-gradient_checkpointing = False
+gradient_checkpointing = True
 
 
 model_config = ModelConfig(
@@ -82,6 +82,7 @@ training_args = GRPOConfig(
     vllm_gpu_memory_utilization=0.5,
     report_to="wandb",
     vllm_device="cuda:3",
+    num_images_per_prompt=4,
 )
 
 

--- a/src/r1_vlm/environments/message_decoding_zoom_in_env/train.py
+++ b/src/r1_vlm/environments/message_decoding_zoom_in_env/train.py
@@ -1,0 +1,100 @@
+import os
+
+from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+from trl import GRPOConfig, ModelConfig
+from trl.trainer.qwen_grpo_trainer import QwenGRPOTrainer
+
+from r1_vlm.environments.message_decoding_zoom_in_env.message_decoding_zoom_in_env import (
+    MessageDecodingZoomInEnv,
+)
+from r1_vlm.tools.message_decoding_zoom_in_tool import ImageHashZoomInTool, set_zoom_in_tool
+
+os.environ["WANDB_ENTITY"] = "groundlightai"
+os.environ["WANDB_PROJECT"] = "message-decoding-zoom-in"
+
+
+
+
+# Flag that determines if gradient checkpointing is used. If it is, we need to set use_cache to False.
+gradient_checkpointing = False
+
+
+model_config = ModelConfig(
+    model_name_or_path="Qwen/Qwen2.5-VL-3B-Instruct",
+    torch_dtype="bfloat16",
+    use_peft=False,
+)
+
+model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+    pretrained_model_name_or_path=model_config.model_name_or_path,
+    torch_dtype=model_config.torch_dtype,
+    use_cache=False,
+)
+
+# use cache if not gradient checkpointing
+if gradient_checkpointing:
+    model.config.use_cache = False
+elif not gradient_checkpointing:
+    model.config.use_cache = True
+else:
+    raise ValueError("Invalid gradient checkpointing value")
+
+
+processor = AutoProcessor.from_pretrained(
+    model_config.model_name_or_path, padding_side="left"
+)
+
+vf_env = MessageDecodingZoomInEnv(processing_class=processor)
+dataset = vf_env.get_dataset()
+rubric = vf_env.get_rubric()
+image_hash_zoom_in_tool = ImageHashZoomInTool(dataset)
+image_hash_zoom_in_tool.build_hash_table(dataset)  # Build the hash table
+set_zoom_in_tool(image_hash_zoom_in_tool)    # Make it available to get_answer
+
+
+
+training_args = GRPOConfig(
+    model_init_kwargs=model_config,
+    output_dir="vlm-r1-message-decoding-zoom-in",
+    learning_rate=1e-6,
+    adam_beta2=0.98,
+    lr_scheduler_type="cosine",
+    warmup_steps=0,
+    logging_steps=1,
+    save_steps=20,
+    save_total_limit=50,
+    num_train_epochs=1,
+    per_device_train_batch_size=5,
+    num_generations=15,
+    gradient_accumulation_steps=4,
+    gradient_checkpointing=gradient_checkpointing,
+    bf16=True,
+    # GRPO specific parameters
+    max_prompt_length=None,  # must be None for vllm + verifiers
+    max_completion_length=1024,
+    beta=0.001,
+    temperature=1.0,
+    sync_ref_model=True,
+    ref_model_sync_steps=64,
+    eval_strategy="no",
+    log_completions=True,
+    use_vllm=True,
+    vllm_gpu_memory_utilization=0.5,
+    report_to="wandb",
+    vllm_device="cuda:3",
+)
+
+
+trainer = QwenGRPOTrainer(
+    model=model,
+    processing_class=processor,
+    reward_funcs=rubric,
+    args=training_args,
+    train_dataset=dataset,
+    env=vf_env,
+)
+
+trainer.train()
+
+#CUDA_VISIBLE_DEVICES=0,1,2,3 uv run accelerate launch --config_file src/r1_vlm/deepspeed_configs/multi_gpu_3only.yaml src/r1_vlm/environments/message_decoding_zoom_in_env/train.py
+

--- a/src/r1_vlm/environments/message_decoding_zoom_in_env/train.py
+++ b/src/r1_vlm/environments/message_decoding_zoom_in_env/train.py
@@ -82,7 +82,7 @@ training_args = GRPOConfig(
     vllm_gpu_memory_utilization=0.5,
     report_to="wandb",
     vllm_device="cuda:3",
-    num_images_per_prompt=4,
+    limit_image_per_prompt=4,
 )
 
 

--- a/src/r1_vlm/environments/multistep_vision_env.py
+++ b/src/r1_vlm/environments/multistep_vision_env.py
@@ -118,18 +118,14 @@ class MultistepVisionEnv(Environment):
                 len(state["prompt_ids"]) :
             ]
 
-            # if we are done, we truncate if necessary
+            # if we are done, we mark the state as completed
+            # we do not want to truncate the completion ids here, 
+            # because the number of image tokens returned from the tools is variable
             if (
                 self.is_completed(state["messages"])
                 or len(state["completion_ids"]) > sampling_params.max_tokens
             ):  # type: ignore
                 state["completed"] = True
-                state["completion_ids"] = state["completion_ids"][
-                    : sampling_params.max_tokens
-                ]
-                state["completion_mask"] = state["completion_mask"][
-                    : len(state["completion_ids"])
-                ]
 
             # otherwise, we get the env response
             else:

--- a/src/r1_vlm/environments/tool_vision_env.py
+++ b/src/r1_vlm/environments/tool_vision_env.py
@@ -228,7 +228,7 @@ class ToolVisionEnv(MultistepVisionEnv):
                 result = self.call_tool(tool_json=parsed.tool, messages=messages, images=images)
                 if isinstance(result, Image):
                     response = {"role": "user", "content": [
-                            {"type": "text", "text": f"<image_name> tool_result_{self._get_step_count(messages)} </image_name>"},
+                            {"type": "text", "text": f"<image_name> tool_result_{self._get_step_count(messages) // 2} </image_name>"},
                             {"type": "image", "image": result},
                         ]
                     }

--- a/src/r1_vlm/environments/tool_vision_env.py
+++ b/src/r1_vlm/environments/tool_vision_env.py
@@ -228,7 +228,7 @@ class ToolVisionEnv(MultistepVisionEnv):
                 result = self.call_tool(tool_json=parsed.tool, messages=messages, images=images)
                 if isinstance(result, Image):
                     response = {"role": "user", "content": [
-                            {"type": "text", "text": f"<image_name> tool_result_{len(messages) // 2} </image_name>"},
+                            {"type": "text", "text": f"<image_name> tool_result_{self._get_step_count(messages)} </image_name>"},
                             {"type": "image", "image": result},
                         ]
                     }

--- a/src/r1_vlm/tools/digits_answer_tool.py
+++ b/src/r1_vlm/tools/digits_answer_tool.py
@@ -55,7 +55,7 @@ class ImageHashTableTool:
         Adds image to the hash table.
         '''
         # check if image's shape is the same as the hash matrix's shape. if not, resize the image to the hash matrix's shape
-        if image.size != self.hash_matrix.shape[:2]:
+        if self.hash_matrix is not None and image.size != self.hash_matrix.shape[:2]:
             image = image.resize(self.hash_matrix.shape[:2])
         
         hash_value = self.hash_image(image)

--- a/src/r1_vlm/tools/digits_answer_tool.py
+++ b/src/r1_vlm/tools/digits_answer_tool.py
@@ -39,11 +39,15 @@ class ImageHashTableTool:
         Hashes the image.
         '''
         
+        # resize the image if necessary 
+        if self.hash_matrix is not None and image.size != self.hash_matrix.shape[:2]:
+            image = image.resize(self.hash_matrix.shape[:2])
+        
         image = np.array(image)
         
         if self.hash_matrix is None:
             self.generate_hash_matrix(image.shape)
-        
+
         # hash the image
         hash_value = np.sum(image * self.hash_matrix)
         

--- a/src/r1_vlm/tools/digits_answer_tool.py
+++ b/src/r1_vlm/tools/digits_answer_tool.py
@@ -54,6 +54,10 @@ class ImageHashTableTool:
         '''
         Adds image to the hash table.
         '''
+        # check if image's shape is the same as the hash matrix's shape. if not, resize the image to the hash matrix's shape
+        if image.size != self.hash_matrix.shape[:2]:
+            image = image.resize(self.hash_matrix.shape[:2])
+        
         hash_value = self.hash_image(image)
         
         if hash_value in self.hash_table:

--- a/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
+++ b/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
@@ -87,6 +87,9 @@ def zoom_in(image_name: str, bbox: tuple[float, float, float, float], **kwargs) 
     
     coordinates = _zoom_in_tool.lookup_image(image_to_use)
 
-    zoomed_in_image = coordinates_based_zoom_in(coordinates, bbox)
+    # convert the bbox from the normalized format to the absolute format
+    bbox = (bbox[0] * image_to_use.width, bbox[1] * image_to_use.height, bbox[2] * image_to_use.width, bbox[3] * image_to_use.height)
+
+    zoomed_in_image = coordinates_based_zoom_in(coordinates, bbox, image_size=image_to_use.width)
 
     return zoomed_in_image

--- a/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
+++ b/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
@@ -64,8 +64,9 @@ def zoom_in(image_name: str, bbox: tuple[float, float, float, float], **kwargs) 
 
     Args:
         image_name: str, the name of the image to zoom in on.
-        bbox: tuple[float, float, float, float], the bounding box to zoom in on. The bounding box is in the format of (x1, y1, x2, y2),
+        bbox: tuple[float, float, float, float], the bounding box to zoom in on. The bounding box is in the format of [x1, y1, x2, y2],
             where (x1, y1) is the top-left corner and (x2, y2) is the bottom-right corner. The coordinates are normalized to the image size and range from 0 to 1.
+            Also note that a valid bbox should have x1 < x2 and y1 < y2.
 
     Returns:
         The zoomed-in image.
@@ -77,6 +78,22 @@ def zoom_in(image_name: str, bbox: tuple[float, float, float, float], **kwargs) 
     '''
     if _zoom_in_tool is None:
         raise ValueError("ZoomInTool not initialized. Call set_zoom_in_tool first.")
+
+    coordinates_names = ["x1", "y1", "x2", "y2"]
+    # check each coordinate and see if it's in the range of 0 to 1
+    invalid_bbox_coordinates = []
+    for coordinate_name, coordinate_value in zip(coordinates_names, bbox):
+        if coordinate_value < 0 or coordinate_value > 1:
+            invalid_bbox_coordinates.append(coordinate_name)
+
+    if len(invalid_bbox_coordinates) > 0:
+        raise ValueError(f"Invalid bbox coordinates: {invalid_bbox_coordinates}. The coordinates should be normalized to the image size and range from 0 to 1.")
+
+    if bbox[0] >= bbox[2]:
+        raise ValueError("Invalid bbox coordinates: x1 should be less than x2.")
+
+    if bbox[1] >= bbox[3]:
+        raise ValueError("Invalid bbox coordinates: y1 should be less than y2.")
     
     images = kwargs["images"]
 

--- a/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
+++ b/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
@@ -1,0 +1,31 @@
+from PIL import Image, ImageDraw
+from r1_vlm.datasets.message_decoding_words_and_sequences_zoom_in.message_decoding_words_and_sequences_zoom_in import get_font
+
+def zoom_in(full_coordinates, bbox, image_size=300) -> Image.Image:
+    """
+    Given the full coordinates of the decoder image, and a bounding box representing the area of the image to zoom in on,
+    return the reconstructed zoomed-in image.
+    Since we want the zoomed-in image to be in high resolution, we need to build the image up from the full coordinates, rather than cropping the image.
+    """
+    # get the coordinates of the bounding box
+    x1, y1, x2, y2 = bbox
+    valid_full_coordinates = {k: v for k, v in full_coordinates.items() if v is not None}
+    shorter_side = min(x2 - x1, y2 - y1)
+    scale_factor = image_size / shorter_side
+    new_image_size = (int((x2 - x1) * scale_factor), int((y2 - y1) * scale_factor))
+
+    # create the new image
+    new_image = Image.new("RGB", new_image_size, "white")
+    draw = ImageDraw.Draw(new_image)
+    
+    # iterate over the valid full coordinates and draw them on the new image
+    # note that the positions and the font sizes are adjusted and scaled up by the scale factor
+    for mapping_text, (x, y, font_size) in valid_full_coordinates.items():
+        # adjust the position by the scale factor
+        new_x = int(x - x1) * scale_factor
+        new_y = int(y - y1) * scale_factor
+        new_font_size = int(font_size * scale_factor)
+        font = get_font(new_font_size)
+        draw.text((new_x, new_y), mapping_text, fill="black", font=font)
+
+    return new_image

--- a/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
+++ b/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
@@ -71,8 +71,8 @@ def zoom_in(image_name: str, bbox: tuple[float, float, float, float], **kwargs) 
         The zoomed-in image.
 
     Examples:
-        <tool>{"name": "zoom_in", "args": {"image_name": "input_image", "bbox": (0.25, 0.30, 0.45, 0.40)}}</tool>
-        <tool>{"name": "zoom_in", "args": {"image_name": "input_image", "bbox": (0.80, 0.10, 0.95, 0.25)}}</tool>
+        <tool>{"name": "zoom_in", "args": {"image_name": "input_image", "bbox": [0.25, 0.30, 0.45, 0.40]}}</tool>
+        <tool>{"name": "zoom_in", "args": {"image_name": "input_image", "bbox": [0.80, 0.10, 0.95, 0.25]}}</tool>
 
     '''
     if _zoom_in_tool is None:

--- a/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
+++ b/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
@@ -85,7 +85,7 @@ def zoom_in(image_name: str, bbox: tuple[float, float, float, float], **kwargs) 
     if image_to_use is None:
         raise ValueError(f"Error: Image {image_name} not found. Valid image names are: {images.keys()}")
     
-    coordinates = _zoom_in_tool.lookup_image(image_to_use)
+    coordinates = _zoom_in_tool.lookup_image(image_to_use)["coordinates"]
 
     # convert the bbox from the normalized format to the absolute format
     bbox = (bbox[0] * image_to_use.width, bbox[1] * image_to_use.height, bbox[2] * image_to_use.width, bbox[3] * image_to_use.height)

--- a/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
+++ b/src/r1_vlm/tools/message_decoding_zoom_in_tool.py
@@ -108,7 +108,7 @@ def zoom_in(image_name: str, bbox: tuple[float, float, float, float], **kwargs) 
     # convert the bbox from the normalized format to the absolute format
     bbox = (bbox[0] * image_to_use.width, bbox[1] * image_to_use.height, bbox[2] * image_to_use.width, bbox[3] * image_to_use.height)
 
-    zoomed_in_image, zoomed_in_full_coordinates = coordinates_based_zoom_in(coordinates, bbox, image_size=image_to_use.width)
+    zoomed_in_image, zoomed_in_full_coordinates = coordinates_based_zoom_in(coordinates, bbox, image_size=400)
 
     # add the zoomed-in full coordinates and the zooomed-in image to the hash table in the tool
     _zoom_in_tool.add_image(zoomed_in_image, {"coordinates": zoomed_in_full_coordinates})


### PR DESCRIPTION
This PR adds the task built upon the original message decoding task, but requires the VLM to use a zoom-in tool to see the actual mappings of specific characters to solve the task. 

In detail, the characters of some mappings of the cryptogram task are shown with a reduced font size, which are not recognizable by the VLM if not zoomed in. When the VLM calls the tool with valid arguments, the zoomed-in region of the cryptogram mappings will be rebuilt with higher resolutions, and returned to the VLM from the tool.