### PR TITLE
Evaluation of GRPO trained models on V*-Bench and HR-bench with zoom-in tool use

### DIFF
--- a/src/r1_vlm/datasets/hr_bench/hr_bench_base_for_eval.py
+++ b/src/r1_vlm/datasets/hr_bench/hr_bench_base_for_eval.py
@@ -1,0 +1,87 @@
+import io
+import string
+import base64
+
+import pandas as pd
+from PIL import Image
+from tqdm import tqdm
+from typing import Any
+from datasets import load_dataset, Dataset
+
+from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
+from r1_vlm.datasets.text_vqa.text_vqa_tool_use_r1 import resize_image
+
+def b64_decode_image(image_b64: str) -> Image.Image:
+    image = Image.open(io.BytesIO(base64.b64decode(image_b64)))
+    return image
+
+def build_prompt_and_image(line):
+
+    image = b64_decode_image(line['image'])
+
+    question = line['question']
+    options = {
+        cand: line[cand]
+        for cand in string.ascii_uppercase
+        if cand in line and not pd.isna(line[cand])
+    }
+    options_prompt = 'Options:\n'
+    for key, item in options.items():
+        options_prompt += f'{key}. {item}\n'
+    hint = line['hint'] if ('hint' in line and not pd.isna(line['hint'])) else None
+    prompt = ''
+    if hint is not None:
+        prompt += f'Hint: {hint}\n'
+    prompt += f'Question: {question}\n'
+    if len(options):
+        prompt += options_prompt
+        prompt += 'Please select the correct answer from the options above. \n'
+
+    msgs = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "You are a helpful assistant.",
+                }
+            ],
+        }
+    ]
+    msgs.append({
+        "role": "user",
+        "content": [
+            {"type": "image", "image": IMAGE_PLACEHOLDER},
+            {"type": "text", "text": prompt},
+        ],
+    })
+
+    return msgs, image
+
+
+def generate_simple_hr_bench_messages(example: dict, max_size: int | None = None) -> dict[str, Any]:
+    msgs, image = build_prompt_and_image(example)
+    # resize the image's width to 1024
+    if max_size is not None:
+        image = resize_image(image, max_size=max_size)
+
+    return {
+        "messages": msgs,
+        "image": image,
+        "index": example["index"],
+        "category": example["category"],
+        "answer": example["answer"],
+    }
+
+
+
+def create_r1_hr_bench_simple_dataset(split: str, max_size: int | None = None) -> Dataset:
+    if split not in ["4k", "8k"]:
+        raise ValueError(f"Invalid split: {split}. Must be either 4k or 8k.")
+    dataset = load_dataset("DreamMr/HR-Bench", split=f"hrbench_{split}")
+    processed_datasets = []
+    for example in tqdm(dataset, desc="Processing HR-bench dataset"):
+        processed_datasets.append(generate_simple_hr_bench_messages(example, max_size))
+
+    return Dataset.from_list(processed_datasets)
+

--- a/src/r1_vlm/datasets/hr_bench/hr_bench_tool_use_r1.py
+++ b/src/r1_vlm/datasets/hr_bench/hr_bench_tool_use_r1.py
@@ -1,0 +1,103 @@
+import os
+import string
+import pandas as pd
+from tqdm import tqdm
+from PIL import Image
+from typing import Any
+from datasets import load_dataset, Dataset
+
+from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
+from r1_vlm.datasets.text_vqa.text_vqa_tool_use_r1 import resize_image
+from r1_vlm.datasets.hr_bench.hr_bench_base_for_eval import b64_decode_image
+
+def build_tool_use_prompt_and_image(line, max_size: int | None = None):
+    image = b64_decode_image(line['image'])
+    # resize the image's width if necessary
+    if max_size is not None:
+        image = resize_image(image, max_size=max_size)
+    image_size = image.size
+    question = line['question']
+    options = {
+        cand: line[cand]
+        for cand in string.ascii_uppercase
+        if cand in line and not pd.isna(line[cand])
+    }
+    options_prompt = 'Options:\n'
+    for key, item in options.items():
+        options_prompt += f'{key}. {item}\n'
+    hint = line['hint'] if ('hint' in line and not pd.isna(line['hint'])) else None
+    prompt = ''
+    if hint is not None:
+        prompt += f'Hint: {hint}\n'
+    prompt += f'Question: {question}\n'
+    if len(options):
+        prompt += options_prompt
+        prompt += 'Please select the correct answer from the options above. \n'
+
+    system_prompt = "REPLACED WITH TOOLS SYSTEM PROMPT"
+
+    instruction = f"""
+    The image size is {image_size}.
+    Please thoroughly think through the question and refine your answer while thinking. You should try to collect the visual evidence you need to support your answer. Then, provide your answer. The answer (which you will provide in the <answer> </answer> tags) should be a single word or phrase directly answering the question.
+    Question: {prompt}
+    """
+
+    r1_messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "<image_name> input_image </image_name>"},
+                {"type": "image", "image": IMAGE_PLACEHOLDER},
+                {"type": "text", "text": instruction},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "\n<think> Let me think step by step.",
+                }
+            ],
+        },
+    ]
+
+    return r1_messages, image
+
+def generate_hr_bench_tool_use_messages(example: dict, max_size: int | None = None) -> dict[str, Any]:
+    msgs, image = build_tool_use_prompt_and_image(example, max_size)
+    return {
+        "messages": msgs,
+        "image": image,
+        "index": example["index"],
+        "category": example["category"],
+        "answer": example["answer"],
+    }
+
+def create_r1_hr_bench_tool_use_dataset(split: str, max_size: int | None = None) -> Dataset:
+    if split not in ["4k", "8k"]:
+        raise ValueError(f"Invalid split: {split}. Must be either 4k or 8k.")
+    dataset = load_dataset("DreamMr/HR-Bench", split=f"hrbench_{split}")
+    processed_datasets = []
+    for example in tqdm(dataset, desc="Processing HR-bench dataset"):
+        processed_datasets.append(generate_hr_bench_tool_use_messages(example, max_size))
+
+    return Dataset.from_list(processed_datasets)
+
+
+
+if __name__ == "__main__":
+    dataset = create_r1_hr_bench_tool_use_dataset(
+        split="4k",
+        max_size=1024,
+    )
+    print(dataset[0])

--- a/src/r1_vlm/datasets/vstar/vstar_base_for_eval.py
+++ b/src/r1_vlm/datasets/vstar/vstar_base_for_eval.py
@@ -1,0 +1,58 @@
+
+import os
+
+from PIL import Image
+from tqdm import tqdm
+from typing import Any
+from datasets import load_dataset, Dataset
+
+from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
+from r1_vlm.datasets.text_vqa.text_vqa_tool_use_r1 import resize_image
+
+
+
+def generate_simple_vstar_messages(example: dict, benchmark_directory: str, max_size: int | None = None) -> dict[str, Any]:
+    question = example["text"]
+    image_path = os.path.join(benchmark_directory, example["image"])
+    image = Image.open(image_path)
+    # resize the image's width to 1024
+    if max_size is not None:
+        image = resize_image(image, max_size=max_size)
+
+    r1_messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "You are a helpful assistant.",
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": IMAGE_PLACEHOLDER},
+                {"type": "text", "text": question},
+            ],
+        },
+    ]
+
+    return {
+        "messages": r1_messages,
+        "image": image,
+        "category": example["category"],
+        "label": example["label"],
+        "question_id": example["question_id"],
+    }
+
+
+
+def create_r1_vstar_simple_dataset(benchmark_directory: str, max_size: int | None = None) -> Dataset:
+    dataset = load_dataset("craigwu/vstar_bench", split="test")
+    processed_datasets = []
+    for example in tqdm(dataset, desc="Processing V*-bench dataset"):
+        processed_datasets.append(generate_simple_vstar_messages(example, benchmark_directory, max_size))
+
+    return Dataset.from_list(processed_datasets)
+

--- a/src/r1_vlm/datasets/vstar/vstar_tool_use_r1.py
+++ b/src/r1_vlm/datasets/vstar/vstar_tool_use_r1.py
@@ -1,0 +1,78 @@
+import os
+from tqdm import tqdm
+from PIL import Image
+from typing import Any
+from datasets import load_dataset, Dataset
+
+from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
+from r1_vlm.datasets.text_vqa.text_vqa_tool_use_r1 import resize_image
+
+def generate_simple_vstar_messages(example: dict, benchmark_directory: str, max_size: int = 1024) -> dict[str, Any]:
+    question = example["text"]
+    image_path = os.path.join(benchmark_directory, example["image"])
+    image = Image.open(image_path)
+    # resize the image's width to 1024
+    image = resize_image(image, max_size=max_size)
+    image_size = image.size
+
+    system_prompt = "REPLACED WITH TOOLS SYSTEM PROMPT"
+
+    instruction = f"""
+    The image size is {image_size}.
+    Please thoroughly think through the question and refine your answer while thinking. You should try to collect the visual evidence you need to support your answer. Then, provide your answer. The answer (which you will provide in the <answer> </answer> tags) should be a single word or phrase directly answering the question.
+    Question: {question}
+    """
+
+    r1_messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "<image_name> input_image </image_name>"},
+                {"type": "image", "image": IMAGE_PLACEHOLDER},
+                {"type": "text", "text": instruction},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "\n<think> Let me think step by step.",
+                }
+            ],
+        },
+    ]
+
+    return {
+        "messages": r1_messages,
+        "image": image,
+        "category": example["category"],
+        "label": example["label"],
+        "question_id": example["question_id"],
+    }
+
+def create_r1_vstar_tool_use_dataset(benchmark_directory: str, max_size: int = 1024) -> Dataset:
+    dataset = load_dataset("craigwu/vstar_bench", split="test")
+    processed_datasets = []
+    for example in tqdm(dataset, desc="Processing V*-bench dataset"):
+        processed_datasets.append(generate_simple_vstar_messages(example, benchmark_directory, max_size))
+
+    return Dataset.from_list(processed_datasets)
+
+
+
+if __name__ == "__main__":
+    dataset = create_r1_vstar_tool_use_dataset(
+        benchmark_directory="/millcreek/data/vstar_bench/",
+        max_size=1024,
+    )
+    print(dataset[0])

--- a/src/r1_vlm/datasets/vstar/vstar_tool_use_r1.py
+++ b/src/r1_vlm/datasets/vstar/vstar_tool_use_r1.py
@@ -7,12 +7,13 @@ from datasets import load_dataset, Dataset
 from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
 from r1_vlm.datasets.text_vqa.text_vqa_tool_use_r1 import resize_image
 
-def generate_simple_vstar_messages(example: dict, benchmark_directory: str, max_size: int = 1024) -> dict[str, Any]:
+def generate_simple_vstar_messages(example: dict, benchmark_directory: str, max_size: int | None = None) -> dict[str, Any]:
     question = example["text"]
     image_path = os.path.join(benchmark_directory, example["image"])
     image = Image.open(image_path)
     # resize the image's width to 1024
-    image = resize_image(image, max_size=max_size)
+    if max_size is not None:
+        image = resize_image(image, max_size=max_size)
     image_size = image.size
 
     system_prompt = "REPLACED WITH TOOLS SYSTEM PROMPT"
@@ -60,7 +61,7 @@ def generate_simple_vstar_messages(example: dict, benchmark_directory: str, max_
         "question_id": example["question_id"],
     }
 
-def create_r1_vstar_tool_use_dataset(benchmark_directory: str, max_size: int = 1024) -> Dataset:
+def create_r1_vstar_tool_use_dataset(benchmark_directory: str, max_size: int | None = None) -> Dataset:
     dataset = load_dataset("craigwu/vstar_bench", split="test")
     processed_datasets = []
     for example in tqdm(dataset, desc="Processing V*-bench dataset"):

--- a/src/r1_vlm/datasets/vstar/vstar_tool_use_r1.py
+++ b/src/r1_vlm/datasets/vstar/vstar_tool_use_r1.py
@@ -7,7 +7,7 @@ from datasets import load_dataset, Dataset
 from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
 from r1_vlm.datasets.text_vqa.text_vqa_tool_use_r1 import resize_image
 
-def generate_simple_vstar_messages(example: dict, benchmark_directory: str, max_size: int | None = None) -> dict[str, Any]:
+def generate_vstar_tool_use_messages(example: dict, benchmark_directory: str, max_size: int | None = None) -> dict[str, Any]:
     question = example["text"]
     image_path = os.path.join(benchmark_directory, example["image"])
     image = Image.open(image_path)
@@ -65,7 +65,7 @@ def create_r1_vstar_tool_use_dataset(benchmark_directory: str, max_size: int | N
     dataset = load_dataset("craigwu/vstar_bench", split="test")
     processed_datasets = []
     for example in tqdm(dataset, desc="Processing V*-bench dataset"):
-        processed_datasets.append(generate_simple_vstar_messages(example, benchmark_directory, max_size))
+        processed_datasets.append(generate_vstar_tool_use_messages(example, benchmark_directory, max_size))
 
     return Dataset.from_list(processed_datasets)
 

--- a/src/r1_vlm/environments/hr_bench_eval/eval_hrbench.py
+++ b/src/r1_vlm/environments/hr_bench_eval/eval_hrbench.py
@@ -1,0 +1,105 @@
+import os
+import json
+import argparse
+from PIL import Image
+from typing import Any
+from transformers import AutoProcessor
+from datasets import load_dataset, Dataset
+from vllm import LLM, SamplingParams
+from vllm.sampling_params import GuidedDecodingParams
+from verifiers.parsers import XMLParser
+from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
+from r1_vlm.environments.hr_bench_eval.hr_bench_eval_env import HRBenchToolEnv
+
+from tqdm import tqdm
+
+def generate_completions(args: argparse.Namespace):
+    vlm = LLM(
+        model=args.model_path,
+        gpu_memory_utilization=0.9,
+        dtype="bfloat16",
+        tensor_parallel_size=args.tensor_parallel_size,
+        enable_prefix_caching=True,
+        limit_mm_per_prompt={"image": args.limit_image_per_prompt, "video": 0},
+    )
+    processor = AutoProcessor.from_pretrained(args.model_path)
+    env = HRBenchToolEnv(processing_class=processor, split=args.split)
+    dataset = env.get_dataset(max_size=args.max_size)
+
+    sampling_params = SamplingParams(
+        temperature=args.temperature,
+        max_tokens=args.max_tokens,
+    )
+
+    batch_size = args.batch_size
+    batches = []
+
+    for example in dataset:
+        if len(batches) == 0:
+            batches.append([example])
+        elif len(batches[-1]) < batch_size:
+            batches[-1].append(example)
+        else:
+            batches.append([example])
+
+    if os.path.exists(args.output_path):
+        with open(args.output_path, "r") as f:
+            results = [json.loads(line) for line in f]
+    else:
+        results = []
+
+    for batch in tqdm(batches):
+        for example in batch:
+            if example["index"] in [result["index"] for result in results]:
+                batch.remove(example)
+                print(f"Skipping example {example['index']} because it already exists")
+
+        if len(batch) == 0:
+            continue
+
+        conversations, texts, processed_batch, vllm_inputs = env.prepare_data(
+            inputs=batch, processing_class=processor
+        )
+
+        completion_ids = env.generate(
+            conversations=conversations,
+            vlm_inputs=vllm_inputs,
+            vlm=vlm,
+            sampling_params=sampling_params,
+        )
+
+        generated_texts = processor.batch_decode(
+            completion_ids["ids"],
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )
+
+        for example, model_answer in zip(batch, generated_texts):
+            correct_answers = example["answer"]
+            result = {
+                "index": example["index"],
+                "gt_answers": correct_answers,
+                "model_answer": model_answer,
+                "correct": correct_answers == model_answer.upper(),
+                "category": example["category"],
+            }
+            results.append(result)
+            with open(args.output_path, "a") as f:
+                f.write(json.dumps(result) + "\n")
+    return results
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, default="Qwen/Qwen2.5-VL-7B-Instruct")
+    parser.add_argument("--split", type=str, default="4k")
+    parser.add_argument("--limit_image_per_prompt", type=int, default=2)
+    parser.add_argument("--temperature", type=float, default=0.1)
+    parser.add_argument("--max_tokens", type=int, default=2048)
+    parser.add_argument("--max_size", type=int, default=None)
+    parser.add_argument("--batch_size", type=int, default=2)
+    parser.add_argument("--tensor_parallel_size", type=int, default=4)
+    parser.add_argument("--output_path", type=str, default="hrbench_results.jsonl")
+    args = parser.parse_args()
+
+    results = generate_completions(args)

--- a/src/r1_vlm/environments/hr_bench_eval/eval_hrbench_base.py
+++ b/src/r1_vlm/environments/hr_bench_eval/eval_hrbench_base.py
@@ -1,0 +1,94 @@
+import os
+import json
+import argparse
+from PIL import Image
+from typing import Any
+from transformers import AutoProcessor
+from datasets import load_dataset, Dataset
+from vllm import LLM, SamplingParams
+from vllm.sampling_params import GuidedDecodingParams
+from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
+from r1_vlm.environments.hr_bench_eval.hr_bench_eval_env import SimpleHRBenchEvalEnv
+
+from tqdm import tqdm
+
+def generate_completions(args: argparse.Namespace):
+    vlm = LLM(
+        model=args.model_path,
+        gpu_memory_utilization=0.9,
+        dtype="bfloat16",
+        tensor_parallel_size=args.tensor_parallel_size,
+        enable_prefix_caching=True,
+        limit_mm_per_prompt={"image": args.limit_image_per_prompt, "video": 0},
+    )
+    processor = AutoProcessor.from_pretrained(args.model_path)
+    env = SimpleHRBenchEvalEnv(processing_class=processor, split=args.split)
+    dataset = env.get_dataset(max_size=args.max_size)
+
+    sampling_params = SamplingParams(
+        temperature=args.temperature,
+        max_tokens=args.max_tokens,
+    )
+
+    batch_size = args.batch_size
+    batches = []
+
+    for example in dataset:
+        if len(batches) == 0:
+            batches.append([example])
+        elif len(batches[-1]) < batch_size:
+            batches[-1].append(example)
+        else:
+            batches.append([example])
+
+    results = []
+    for batch in tqdm(batches):
+        conversations, texts, processed_batch, vllm_inputs = env.prepare_data(
+            inputs=batch, processing_class=processor, add_generation_prompt=True
+        )
+
+        completion_ids = env.generate(
+            conversations=conversations,
+            vlm_inputs=vllm_inputs,
+            vlm=vlm,
+            sampling_params=sampling_params,
+        )
+
+        generated_texts = processor.batch_decode(
+            completion_ids["ids"],
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )
+
+        for example, model_answer in zip(batch, generated_texts):
+            correct_answers = example["answer"]
+
+            result = {
+                "index": example["index"],
+                "gt_answers": correct_answers,
+                "model_answer": model_answer,
+                "correct": correct_answers == model_answer.upper(),
+                "category": example["category"],
+            }
+            results.append(result)
+            with open(args.output_path, "a") as f:
+                f.write(json.dumps(result) + "\n")
+    return results
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, default="Qwen/Qwen2.5-VL-3B-Instruct")
+    parser.add_argument("--split", type=str, default="4k")
+    parser.add_argument("--limit_image_per_prompt", type=int, default=1)
+    parser.add_argument("--temperature", type=float, default=0.)
+    parser.add_argument("--max_tokens", type=int, default=512)
+    parser.add_argument("--max_size", type=int, default=None)
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--tensor_parallel_size", type=int, default=4)
+    parser.add_argument("--output_path", type=str, default="hrbench_results.jsonl")
+    args = parser.parse_args()
+
+    results = generate_completions(args)
+    accuracy = sum([1 if result["correct"] else 0 for result in results]) / len(results)
+    print(f"Accuracy: {accuracy * 100:.2f}%")

--- a/src/r1_vlm/environments/hr_bench_eval/eval_hrbench_base.py
+++ b/src/r1_vlm/environments/hr_bench_eval/eval_hrbench_base.py
@@ -49,6 +49,16 @@ def generate_completions(args: argparse.Namespace):
 
     eval_indices = [result["index"] for result in results]
     for batch in tqdm(batches):
+        for example in batch:
+            if example["index"] in eval_indices:
+                print(f"Skipping example {example['index']} because it has already been evaluated")
+                batch.remove(example)
+                continue
+            else:
+                eval_indices.append(example["index"])
+        if len(batch) == 0:
+            continue
+
         conversations, texts, processed_batch, vllm_inputs = env.prepare_data(
             inputs=batch, processing_class=processor, add_generation_prompt=True
         )
@@ -67,9 +77,6 @@ def generate_completions(args: argparse.Namespace):
         )
 
         for example, model_answer in zip(batch, generated_texts):
-            if example["index"] in eval_indices:
-                print(f"Skipping example {example['index']} because it has already been evaluated")
-                continue
             correct_answers = example["answer"]
 
             result = {

--- a/src/r1_vlm/environments/hr_bench_eval/hr_bench_eval_env.py
+++ b/src/r1_vlm/environments/hr_bench_eval/hr_bench_eval_env.py
@@ -57,7 +57,7 @@ class HRBenchToolEnv(ToolVisionEnv):
     def __init__(
         self,
         processing_class: AutoProcessor,
-        benchmark_directory: str,
+        split: str,
         tools_with_parsers: list[tuple[Callable, ToolArgParser]] = [
             (zoom, parse_zoom_args),
         ],
@@ -71,7 +71,7 @@ class HRBenchToolEnv(ToolVisionEnv):
             tool_prompt_template=tool_prompt_template,
         )
 
-        self.benchmark_directory = benchmark_directory
+        self.split = split
         self.parser = XMLParser(fields=["think", "answer", "tool"])
         self._fields = [
             ("think", ["think"]),

--- a/src/r1_vlm/environments/hr_bench_eval/hr_bench_eval_env.py
+++ b/src/r1_vlm/environments/hr_bench_eval/hr_bench_eval_env.py
@@ -1,0 +1,95 @@
+import json
+import re
+from typing import Any, Callable
+
+from PIL import Image
+from transformers import AutoProcessor
+from datasets import Dataset
+from verifiers.parsers import XMLParser
+
+from r1_vlm.datasets.text_vqa.text_vqa_r1 import (
+    create_r1_text_vqa_dataset,
+)
+from r1_vlm.datasets.utils import preprocess_r1_dataset
+from r1_vlm.environments.multistep_vision_env import MultistepVisionEnv
+from r1_vlm.environments.simple_vision_env import SimpleVisionEnv
+from r1_vlm.environments.tool_use_text_vqa_env.find_examples_for_training import (
+    find_examples_for_training,
+)
+from r1_vlm.environments.tool_vision_env import ToolArgParser, ToolVisionEnv
+from r1_vlm.datasets.hr_bench.hr_bench_base_for_eval import create_r1_hr_bench_simple_dataset
+from r1_vlm.datasets.hr_bench.hr_bench_tool_use_r1 import create_r1_hr_bench_tool_use_dataset
+from r1_vlm.tools.tool_prompts import SINGLE_TOOL_PROMPT_TEMPLATE_SIMPLIFIED
+from r1_vlm.tools.zoom import parse_zoom_args, zoom
+
+
+class SimpleHRBenchEvalEnv(SimpleVisionEnv):
+    def __init__(
+        self,
+        split: str,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.split = split
+        self.parser = XMLParser(fields=["think", "answer"])
+        self._fields = [
+            ("think", ["think"]),
+            ("answer", ["answer"]),
+        ]
+
+    def parse(self, text: str, strip: bool = True):
+        return self.parser.parse(text, strip=strip)
+
+    def get_dataset(self, max_size: int | None = None) -> Dataset:
+        dataset = create_r1_hr_bench_simple_dataset(
+            split=self.split,
+            max_size=max_size,
+        )
+        dataset = preprocess_r1_dataset(dataset)
+        return dataset
+
+    def get_rubric(self):
+        raise NotImplementedError(
+            "get_rubric is not implemented for SimpleVStarEvalEnv because the env is used for evaluation only"
+        )
+
+class HRBenchToolEnv(ToolVisionEnv):
+    def __init__(
+        self,
+        processing_class: AutoProcessor,
+        benchmark_directory: str,
+        tools_with_parsers: list[tuple[Callable, ToolArgParser]] = [
+            (zoom, parse_zoom_args),
+        ],
+        max_steps: int = 3,
+        tool_prompt_template: str = SINGLE_TOOL_PROMPT_TEMPLATE_SIMPLIFIED,
+    ):
+        super().__init__(
+            processing_class=processing_class,
+            tools_with_parsers=tools_with_parsers,
+            max_steps=max_steps,
+            tool_prompt_template=tool_prompt_template,
+        )
+
+        self.benchmark_directory = benchmark_directory
+        self.parser = XMLParser(fields=["think", "answer", "tool"])
+        self._fields = [
+            ("think", ["think"]),
+            ("answer", ["answer"]),
+            ("tool", ["tool"]),
+        ]
+
+    def parse(self, text: str, strip: bool = True):
+        return self.parser.parse(text, strip=strip)
+
+    def get_dataset(
+        self,
+        max_size: int | None = None,
+    ) -> Dataset:
+        dataset = create_r1_hr_bench_tool_use_dataset(
+            split=self.split,
+            max_size=max_size,
+        )
+        dataset = self.inject_system_prompt(dataset)
+        dataset = preprocess_r1_dataset(dataset)
+        return dataset

--- a/src/r1_vlm/environments/hr_bench_eval/hr_bench_eval_env.py
+++ b/src/r1_vlm/environments/hr_bench_eval/hr_bench_eval_env.py
@@ -90,6 +90,7 @@ class HRBenchToolEnv(ToolVisionEnv):
             split=self.split,
             max_size=max_size,
         )
-        dataset = self.inject_system_prompt(dataset)
+        # for 8k, batched need to be set as False because the dataset is too large
+        dataset = self.inject_system_prompt(dataset, batched=self.split == "4k")
         dataset = preprocess_r1_dataset(dataset)
         return dataset

--- a/src/r1_vlm/environments/multistep_vision_env.py
+++ b/src/r1_vlm/environments/multistep_vision_env.py
@@ -245,7 +245,7 @@ class MultistepVisionEnv(Environment):
         total_steps = 2
 
         # flag to turn on/off structured output on the last step
-        should_use_structured_output_last_step = False
+        should_use_structured_output_last_step = True
 
         # main loop
         while not all_completed:

--- a/src/r1_vlm/environments/simple_vision_env.py
+++ b/src/r1_vlm/environments/simple_vision_env.py
@@ -161,12 +161,12 @@ class SimpleVisionEnv(SimpleEnv):
             "mask": completion_masks,
         }
 
-    def prepare_data(self, *, inputs, processing_class):
+    def prepare_data(self, *, inputs, processing_class, add_generation_prompt=False):
         """
         prepares the data to be used for forward pass with VLLM and logprobs calculations with hf
         """
         conversations, texts, batch, vllm_inputs = prepare_inputs_for_env(
-            inputs=inputs, processing_class=processing_class
+            inputs=inputs, processing_class=processing_class, add_generation_prompt=add_generation_prompt
         )
 
         return conversations, texts, batch, vllm_inputs
@@ -180,7 +180,7 @@ class SimpleVisionEnv(SimpleEnv):
         return {}
 
 
-def prepare_inputs_for_env(*, inputs, processing_class):
+def prepare_inputs_for_env(*, inputs, processing_class, add_generation_prompt=False):
     """
     Prepares inputs for an env's .generate method.
 
@@ -202,7 +202,7 @@ def prepare_inputs_for_env(*, inputs, processing_class):
 
     # apply the chat template to the messages and add image tokens
     texts = processing_class.apply_chat_template(
-        conversations, continue_final_message=True, tokenize=False
+        conversations, continue_final_message=not add_generation_prompt, tokenize=False, add_generation_prompt=add_generation_prompt
     )
 
     vllm_inputs = []

--- a/src/r1_vlm/environments/tool_use_text_vqa_env/eval_base_textcot.py
+++ b/src/r1_vlm/environments/tool_use_text_vqa_env/eval_base_textcot.py
@@ -139,6 +139,7 @@ def create_text_vqa_textcot_base_for_eval_dataset(
     splits_to_process: list[str] | None = None,
     max_examples_per_split: int | None = None,
     stage: int = 1,
+    idx_to_start: int = 0,
 ):
     dataset = load_dataset("lmms-lab/textvqa")
     process_fn = process_textcot_stage1_example if stage == 1 else process_textcot_stage2_example
@@ -155,7 +156,8 @@ def create_text_vqa_textcot_base_for_eval_dataset(
     for split in splits_to_process:
         print(f"Processing {split} split...")
         examples = []
-        for example in tqdm(dataset[split], desc=f"Processing {split} examples"):
+        selected_dataset = dataset[split].select(range(idx_to_start, len(dataset[split]))) if idx_to_start > 0 else dataset[split]
+        for example in tqdm(selected_dataset, desc=f"Processing {split} examples"):
             processed_example = process_fn(example)
             examples.append(processed_example)
 
@@ -277,6 +279,7 @@ if __name__ == "__main__":
     parser.add_argument("--split", type=str, default="train")
     parser.add_argument("--max_examples_per_split", type=int, default=None)
     parser.add_argument("--do_base_eval", action="store_true")
+    parser.add_argument("--idx_to_start", type=int, default=0)
     args = parser.parse_args()
 
     os.makedirs(args.results_dir_path, exist_ok=True)
@@ -295,8 +298,8 @@ if __name__ == "__main__":
         stop_token_ids=[],
     )
 
-    stage_1_dataset = create_text_vqa_textcot_base_for_eval_dataset(splits_to_process=[args.split], stage=1, max_examples_per_split=args.max_examples_per_split)
-    stage_2_dataset = create_text_vqa_textcot_base_for_eval_dataset(splits_to_process=[args.split], stage=2, max_examples_per_split=args.max_examples_per_split)
+    stage_1_dataset = create_text_vqa_textcot_base_for_eval_dataset(splits_to_process=[args.split], stage=1, max_examples_per_split=args.max_examples_per_split, idx_to_start=args.idx_to_start)
+    stage_2_dataset = create_text_vqa_textcot_base_for_eval_dataset(splits_to_process=[args.split], stage=2, max_examples_per_split=args.max_examples_per_split, idx_to_start=args.idx_to_start)
 
 
     # stage 1

--- a/src/r1_vlm/environments/tool_use_text_vqa_env/eval_base_textcot.py
+++ b/src/r1_vlm/environments/tool_use_text_vqa_env/eval_base_textcot.py
@@ -310,6 +310,7 @@ if __name__ == "__main__":
         stage_1_results = inference(llm, processor, sampling_params, dataset)
         save_jsonl(stage_1_results, os.path.join(args.results_dir_path, "stage_1_results.jsonl"))
     else:
+        print("Loading stage 1 results from cache...")
         stage_1_results = load_jsonl(os.path.join(args.results_dir_path, "stage_1_results.jsonl"))
 
     if not os.path.exists(os.path.join(args.results_dir_path, "stage_2_results.jsonl")):
@@ -319,6 +320,7 @@ if __name__ == "__main__":
         stage_2_results = inference(llm, processor, sampling_params, dataset)
         save_jsonl(stage_2_results, os.path.join(args.results_dir_path, "stage_2_results.jsonl"))
     else:
+        print("Loading stage 2 results from cache...")
         stage_2_results = load_jsonl(os.path.join(args.results_dir_path, "stage_2_results.jsonl"))
     # extract the bounding box from the generated text
     bounding_box_pattern = r"\[(\d+), (\d+), (\d+), (\d+)\]"
@@ -341,6 +343,7 @@ if __name__ == "__main__":
             result = evaluate_result(result)
         save_jsonl(stage_3_results, os.path.join(args.results_dir_path, "stage_3_results.jsonl"))
     else:
+        print("Loading stage 3 results from cache...")
         stage_3_results = load_jsonl(os.path.join(args.results_dir_path, "stage_3_results.jsonl"))
 
     print("Textcot avg score: ", evaluate(stage_3_results))

--- a/src/r1_vlm/environments/tool_use_text_vqa_env/eval_base_textcot.py
+++ b/src/r1_vlm/environments/tool_use_text_vqa_env/eval_base_textcot.py
@@ -1,0 +1,334 @@
+import os
+import re
+import json
+
+from copy import deepcopy
+from qwen_vl_utils import process_vision_info
+from tqdm import tqdm
+from transformers import AutoProcessor
+from vllm import LLM, SamplingParams
+from datasets import Dataset, DatasetDict, load_dataset
+
+from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
+from r1_vlm.datasets.text_vqa.text_vqa_base_for_eval import (
+    create_text_vqa_base_for_eval_dataset,
+)
+from r1_vlm.datasets.utils import preprocess_r1_dataset
+from r1_vlm.environments.tool_use_text_vqa_env.tool_use_text_vqa_env import (
+    normalize_answer,
+)
+
+# evaluating the base model on the validation set.
+
+
+def evaluate_result(result: dict):
+    gt_answers = result["gt_answers"]
+    generated_text = result["generated_text"]
+    normalized_model_answer, normalized_correct_answers = normalize_answer(
+        model_answer=generated_text, correct_answers=gt_answers
+    )
+
+    total_matches = sum(
+        [
+            1
+            for answer in normalized_correct_answers
+            if answer == normalized_model_answer
+        ]
+    )
+    vqa_score = total_matches / 3.0
+    vqa_score = min(1, vqa_score)
+
+    result["vqa_score"] = vqa_score
+
+    return result
+
+
+def evaluate(results: list[dict]):
+    total_score = 0
+    total_count = 0
+    for result in results:
+        total_count += 1
+
+        total_score += result["vqa_score"]
+
+    return total_score / total_count
+
+def resize_image(image, max_size=1024):
+    # if the longer side is greater than 1024, resize it so the longer side is 1024
+    if image.size[0] > max_size or image.size[1] > max_size:
+        longer_side = max(image.size[0], image.size[1])
+        image = image.resize(
+            (
+                int(max_size * image.size[0] / longer_side),
+                int(max_size * image.size[1] / longer_side),
+            )
+        )
+
+    return image
+
+def process_textcot_stage1_example(example):
+    # unpack the example
+    image_id = example["image_id"]
+    question_id = example["question_id"]
+    question = example["question"]
+    # NOTE: We resize the image here if it is too large
+    raw_image = deepcopy(example["image"])
+    image = resize_image(example["image"], max_size=1024)
+    answers = example["answers"]
+
+    instruction = f"Describe the scene in the image in one sentence."
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": IMAGE_PLACEHOLDER,
+                },
+                {"type": "text", "text": instruction},
+            ],
+        }
+    ]
+
+    return {
+        "messages": messages,
+        "image": image,
+        "raw_image": raw_image,
+        "image_id": image_id,
+        "question_id": question_id,
+        "question": question,
+        "answers": answers,
+    }
+
+def process_textcot_stage2_example(example):
+    # unpack the example
+    image_id = example["image_id"]
+    question_id = example["question_id"]
+    question = example["question"]
+    # NOTE: We resize the image here if it is too large
+    raw_image = deepcopy(example["image"])
+    image = resize_image(example["image"], max_size=1024)
+    answers = example["answers"]
+
+    instruction = f"{question}\nThe image size is {image.size}. According to the information in the image and the question, \ndetail the bounding box coordinates of the answer in the scene in JSON format: [x1, y1, x2, y2]. All coordinates should be integers representing the pixel values of the bounding box. "
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": IMAGE_PLACEHOLDER,
+                },
+                {"type": "text", "text": instruction},
+            ],
+        }
+    ]
+
+    return {
+        "messages": messages,
+        "image": image,
+        "raw_image": raw_image,
+        "image_id": image_id,
+        "question_id": question_id,
+        "question": question,
+        "answers": answers,
+    }
+
+
+def create_text_vqa_textcot_base_for_eval_dataset(
+    splits_to_process: list[str] | None = None,
+    max_examples_per_split: int | None = None,
+    stage: int = 1,
+):
+    dataset = load_dataset("lmms-lab/textvqa")
+    process_fn = process_textcot_stage1_example if stage == 1 else process_textcot_stage2_example
+
+    valid_splits = ["train", "validation", "test"]
+    if splits_to_process is None:
+        splits_to_process = valid_splits
+    else:
+        for split in splits_to_process:
+            if split not in valid_splits:
+                raise ValueError(f"Invalid split: {split}")
+
+    processed_datasets = {}
+    for split in splits_to_process:
+        print(f"Processing {split} split...")
+        examples = []
+        for example in tqdm(dataset[split], desc=f"Processing {split} examples"):
+            processed_example = process_fn(example)
+            examples.append(processed_example)
+
+            if (
+                max_examples_per_split is not None
+                and len(examples) >= max_examples_per_split
+            ):
+                break
+
+        processed_datasets[split] = Dataset.from_list(examples)
+
+    return DatasetDict(processed_datasets)
+
+
+def process_textcot_stage3_example(example, result1, result2):
+    # unpack the example
+    context = result1['generated_text']
+    bounding_box = result2['bounding_box']
+    instruction = f"This is the context of the scene: {context}\nUse the image and text information as context and answer the following question:\n{example['question']}\nAnswer the question using a single word or phrase."
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": IMAGE_PLACEHOLDER,
+                },
+                {"type": "text", "text": instruction},
+            ],
+        }
+    ]
+    # zoom in to the bounding box
+    zoomed_in_image = example["image"]
+    # check if the raw image is downsized: if so, we apply the zoom to the raw image
+    if example["raw_image"].size != example["image"].size:
+        scale = example["raw_image"].size[0] / example["image"].size[0]
+        scaled_bounding_box = [int(coord * scale) for coord in bounding_box]
+        zoomed_in_image = example["raw_image"].crop(scaled_bounding_box)
+    else:
+        zoomed_in_image = example["image"].crop(bounding_box)
+
+    example["messages"] = messages
+    example["image"] = zoomed_in_image
+    return example
+
+def create_text_vqa_textcot_stage3_base_for_eval_dataset(
+    dataset: Dataset,
+    prev_stage1_results: list[dict],
+    prev_stage2_results: list[dict],
+) -> Dataset:
+    if len(dataset) != len(prev_stage1_results):
+        raise ValueError(f"The length of the dataset and the previous stage results must be the same. \nDataset length: {len(dataset)}\nPrevious stage results length: {len(prev_stage1_results)}")
+
+    if len(dataset) != len(prev_stage2_results):
+        raise ValueError(f"The length of the dataset and the previous stage results must be the same. \nDataset length: {len(dataset)}\nPrevious stage results length: {len(prev_stage2_results)}")
+
+    examples = []
+    for example, result1, result2 in zip(dataset, prev_stage1_results, prev_stage2_results):
+        bounding_box = result2["bounding_box"]
+        if bounding_box is None:
+            continue
+        processed_example = process_textcot_stage3_example(example, result1, result2)
+        examples.append(processed_example)
+
+    return Dataset.from_list(examples)
+
+
+def inference(llm, processor, sampling_params, dataset):
+    results = []
+    for example in tqdm(dataset):
+        if example["question_id"] in [result["question_id"] for result in results]:
+            continue
+
+        messages = example["messages"]
+        for message in messages:
+            content = message["content"]
+            message["content"] = [
+                {k: v for k, v in item.items() if v is not None} for item in content
+            ]
+
+        text = processor.apply_chat_template(
+            messages,
+            continue_final_message=False,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+        vllm_inputs = []
+
+        vllm_image_inputs, _ = process_vision_info(messages)
+        mm_data = {"image": vllm_image_inputs}
+        vllm_input = {"prompt": text, "multi_modal_data": mm_data}
+        vllm_inputs.append(vllm_input)
+
+        outputs = llm.generate(vllm_inputs, sampling_params=sampling_params)
+        generated_text = outputs[0].outputs[0].text
+
+        result = {
+            "question_id": example["question_id"],
+            "gt_answers": example["answers"],
+            "generated_text": generated_text,
+        }
+        # result = evaluate_result(result)
+        results.append(result)
+
+    return results
+
+
+if __name__ == "__main__":
+    MODEL_PATH = "Qwen/Qwen2.5-VL-3B-Instruct"
+    results_file_path = "/millcreek/home/bowen/Projects/r1_vlm/results/base_textcot_eval_on_training_results.jsonl"
+
+    llm = LLM(
+        model=MODEL_PATH,
+        limit_mm_per_prompt={"image": 1, "video": 0},
+        tensor_parallel_size=4,
+        gpu_memory_utilization=1.0,
+    )
+
+    sampling_params = SamplingParams(
+        temperature=0.1,
+        max_tokens=128,
+        stop_token_ids=[],
+    )
+
+    stage_1_dataset = create_text_vqa_textcot_base_for_eval_dataset(splits_to_process=["validation"], stage=1)
+    stage_2_dataset = create_text_vqa_textcot_base_for_eval_dataset(splits_to_process=["validation"], stage=2)
+
+    processor = AutoProcessor.from_pretrained(MODEL_PATH)
+
+    if os.path.exists(results_file_path):
+        with open(results_file_path, "r") as f:
+            results = [json.loads(line) for line in f]
+
+    # stage 1
+    dataset = preprocess_r1_dataset(stage_1_dataset['validation'])
+    stage_1_results = inference(llm, processor, sampling_params, dataset)
+
+    # stage 2
+    dataset = preprocess_r1_dataset(stage_2_dataset['validation'])
+    stage_2_results = inference(llm, processor, sampling_params, dataset)
+    # extract the bounding box from the generated text
+    bounding_box_pattern = r"\[(\d+), (\d+), (\d+), (\d+)\]"
+    for result in stage_2_results:
+        generated_text = result["generated_text"]
+        # extract the bounding box from the generated text
+        bounding_box = re.search(bounding_box_pattern, generated_text)
+        if bounding_box:
+            bounding_box = [int(coord) for coord in bounding_box.groups()]
+            result["bounding_box"] = bounding_box
+        else:
+            result["bounding_box"] = None
+        
+    # stage 3
+    stage_3_dataset = create_text_vqa_textcot_stage3_base_for_eval_dataset(stage_1_dataset['validation'], stage_1_results, stage_2_results)
+    dataset = preprocess_r1_dataset(dataset)
+    stage_3_results = inference(llm, processor, sampling_params, dataset)
+    for result in stage_3_results:
+        result = evaluate_result(result)
+
+    print("Textcot avg score: ", evaluate(stage_3_results))
+        # current_score = evaluate(results)
+        # print(f"Current score: {current_score}")
+
+        # with open(results_file_path, "a") as f:
+        #     f.write(json.dumps(result) + "\n")
+    dataset = create_text_vqa_base_for_eval_dataset(splits_to_process=["validation"])
+    dataset = preprocess_r1_dataset(dataset['validation'])
+    results = inference(llm, processor, sampling_params, dataset)
+    for result in results:
+        result = evaluate_result(result)
+
+    print("Base avg score: ", evaluate(results))

--- a/src/r1_vlm/environments/tool_use_text_vqa_env/eval_base_textcot.py
+++ b/src/r1_vlm/environments/tool_use_text_vqa_env/eval_base_textcot.py
@@ -280,6 +280,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_examples_per_split", type=int, default=None)
     parser.add_argument("--do_base_eval", action="store_true")
     parser.add_argument("--idx_to_start", type=int, default=0)
+    parser.add_argument("--num_gpus", type=int, default=4)
     args = parser.parse_args()
 
     os.makedirs(args.results_dir_path, exist_ok=True)
@@ -288,7 +289,7 @@ if __name__ == "__main__":
     llm = LLM(
         model=args.model_path,
         limit_mm_per_prompt={"image": 1, "video": 0},
-        tensor_parallel_size=4,
+        tensor_parallel_size=args.num_gpus,
         gpu_memory_utilization=1.0,
     )
 

--- a/src/r1_vlm/environments/tool_vision_env.py
+++ b/src/r1_vlm/environments/tool_vision_env.py
@@ -168,7 +168,7 @@ class ToolVisionEnv(MultistepVisionEnv):
         # can end early if the model provides an answer.
         self.max_steps = max_steps
 
-    def inject_system_prompt(self, dataset: Dataset) -> Dataset:
+    def inject_system_prompt(self, dataset: Dataset, batched: bool = True) -> Dataset:
         """
         Called by inherited class to inject a system prompt containing tool schemas into the given dataset.
 
@@ -207,7 +207,7 @@ class ToolVisionEnv(MultistepVisionEnv):
 
             return examples
 
-        return dataset.map(_inject_prompt, batched=True)
+        return dataset.map(_inject_prompt, batched=batched)
 
     def get_rubric(self) -> List[RewardFunc]:
         raise NotImplementedError(

--- a/src/r1_vlm/environments/tool_vision_env.py
+++ b/src/r1_vlm/environments/tool_vision_env.py
@@ -180,34 +180,40 @@ class ToolVisionEnv(MultistepVisionEnv):
 
         def _inject_prompt(examples):
             messages_batch = examples["messages"]
-
             for messages in messages_batch:
-                if not messages or messages[0]["role"] != "system":
-                    raise ValueError("Expected first message to be a system message")
-
-                # Create a shuffled copy of tool schemas for this sample
-                shuffled_schemas = self.tool_schemas[:]  # Create a copy
-                random.shuffle(shuffled_schemas)
-
-                # Format tool descriptions with the shuffled order
-                tool_descriptions = format_tool_descriptions(shuffled_schemas)
-
-                # Format the prompt template with the randomized descriptions
-                formatted_prompt = self.tool_prompt_template.format(
-                    tool_descriptions=tool_descriptions
-                )
-
-                # Replace the content of the system message with the formatted prompt
-                messages[0]["content"] = [
-                    {
-                        "type": "text",
-                        "text": formatted_prompt,
-                    }
-                ]
-
+                _inject_prompt_to_messages(messages)
             return examples
 
-        return dataset.map(_inject_prompt, batched=batched)
+        def _inject_prompt_to_messages(messages):
+            if not messages or messages[0]["role"] != "system":
+                raise ValueError("Expected first message to be a system message")
+            
+            # Create a shuffled copy of tool schemas for this sample
+            shuffled_schemas = self.tool_schemas[:]  # Create a copy
+            random.shuffle(shuffled_schemas)
+
+            # Format tool descriptions with the shuffled order
+            tool_descriptions = format_tool_descriptions(shuffled_schemas)
+
+            # Format the prompt template with the randomized descriptions
+            formatted_prompt = self.tool_prompt_template.format(
+                tool_descriptions=tool_descriptions
+            )
+
+            # Replace the content of the system message with the formatted prompt
+            messages[0]["content"] = [
+                {
+                    "type": "text",
+                    "text": formatted_prompt,
+                }
+            ]
+
+        if batched:
+            return dataset.map(_inject_prompt, batched=True)
+        else:
+            for messages in dataset["messages"]:
+                _inject_prompt_to_messages(messages)
+            return dataset
 
     def get_rubric(self) -> List[RewardFunc]:
         raise NotImplementedError(

--- a/src/r1_vlm/environments/vstar_eval/eval_vstar.py
+++ b/src/r1_vlm/environments/vstar_eval/eval_vstar.py
@@ -59,7 +59,7 @@ def generate_completions(args: argparse.Namespace):
     )
     processor = AutoProcessor.from_pretrained(args.model_path)
     env = VStarToolEnv(processing_class=processor, benchmark_directory=args.benchmark_directory)
-    dataset = env.get_dataset()
+    dataset = env.get_dataset(max_size=args.max_size)
 
     sampling_params = SamplingParams(
         temperature=args.temperature,
@@ -119,6 +119,7 @@ if __name__ == "__main__":
     parser.add_argument("--limit_image_per_prompt", type=int, default=2)
     parser.add_argument("--temperature", type=float, default=0.1)
     parser.add_argument("--max_tokens", type=int, default=2048)
+    parser.add_argument("--max_size", type=int, default=None)
     parser.add_argument("--batch_size", type=int, default=2)
     parser.add_argument("--tensor_parallel_size", type=int, default=4)
     parser.add_argument("--output_path", type=str, default="vstar_results.jsonl")

--- a/src/r1_vlm/environments/vstar_eval/vstar_eval_env.py
+++ b/src/r1_vlm/environments/vstar_eval/vstar_eval_env.py
@@ -17,6 +17,7 @@ from r1_vlm.environments.tool_use_text_vqa_env.find_examples_for_training import
     find_examples_for_training,
 )
 from r1_vlm.environments.tool_vision_env import ToolArgParser, ToolVisionEnv
+from r1_vlm.datasets.vstar.vstar_base_for_eval import create_r1_vstar_simple_dataset
 from r1_vlm.datasets.vstar.vstar_tool_use_r1 import create_r1_vstar_tool_use_dataset
 from r1_vlm.tools.tool_prompts import SINGLE_TOOL_PROMPT_TEMPLATE_SIMPLIFIED
 from r1_vlm.tools.zoom import parse_zoom_args, zoom
@@ -25,11 +26,11 @@ from r1_vlm.tools.zoom import parse_zoom_args, zoom
 class SimpleVStarEvalEnv(SimpleVisionEnv):
     def __init__(
         self,
-        dataset_name: str = None,
+        benchmark_directory: str,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.dataset_name = dataset_name
+        self.benchmark_directory = benchmark_directory
         self.parser = XMLParser(fields=["think", "answer"])
         self._fields = [
             ("think", ["think"]),
@@ -39,8 +40,13 @@ class SimpleVStarEvalEnv(SimpleVisionEnv):
     def parse(self, text: str, strip: bool = True):
         return self.parser.parse(text, strip=strip)
 
-    def get_dataset(self) -> Dataset:
-        raise NotImplementedError("V*-bench is not implemented yet")
+    def get_dataset(self, max_size: int | None = None) -> Dataset:
+        dataset = create_r1_vstar_simple_dataset(
+            benchmark_directory=self.benchmark_directory,
+            max_size=max_size,
+        )
+        dataset = preprocess_r1_dataset(dataset)
+        return dataset
 
 class VStarToolEnv(ToolVisionEnv):
     def __init__(

--- a/src/r1_vlm/environments/vstar_eval/vstar_eval_env.py
+++ b/src/r1_vlm/environments/vstar_eval/vstar_eval_env.py
@@ -1,0 +1,84 @@
+import json
+import re
+from typing import Any, Callable
+
+from PIL import Image
+from transformers import AutoProcessor
+from datasets import Dataset
+from verifiers.parsers import XMLParser
+
+from r1_vlm.datasets.text_vqa.text_vqa_r1 import (
+    create_r1_text_vqa_dataset,
+)
+from r1_vlm.datasets.utils import preprocess_r1_dataset
+from r1_vlm.environments.multistep_vision_env import MultistepVisionEnv
+from r1_vlm.environments.simple_vision_env import SimpleVisionEnv
+from r1_vlm.environments.tool_use_text_vqa_env.find_examples_for_training import (
+    find_examples_for_training,
+)
+from r1_vlm.environments.tool_vision_env import ToolArgParser, ToolVisionEnv
+from r1_vlm.datasets.vstar.vstar_tool_use_r1 import create_r1_vstar_tool_use_dataset
+from r1_vlm.tools.tool_prompts import SINGLE_TOOL_PROMPT_TEMPLATE_SIMPLIFIED
+from r1_vlm.tools.zoom import parse_zoom_args, zoom
+
+
+class SimpleVStarEvalEnv(SimpleVisionEnv):
+    def __init__(
+        self,
+        dataset_name: str = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.dataset_name = dataset_name
+        self.parser = XMLParser(fields=["think", "answer"])
+        self._fields = [
+            ("think", ["think"]),
+            ("answer", ["answer"]),
+        ]
+
+    def parse(self, text: str, strip: bool = True):
+        return self.parser.parse(text, strip=strip)
+
+    def get_dataset(self) -> Dataset:
+        raise NotImplementedError("V*-bench is not implemented yet")
+
+class VStarToolEnv(ToolVisionEnv):
+    def __init__(
+        self,
+        processing_class: AutoProcessor,
+        benchmark_directory: str,
+        tools_with_parsers: list[tuple[Callable, ToolArgParser]] = [
+            (zoom, parse_zoom_args),
+        ],
+        max_steps: int = 3,
+        tool_prompt_template: str = SINGLE_TOOL_PROMPT_TEMPLATE_SIMPLIFIED,
+    ):
+        super().__init__(
+            processing_class=processing_class,
+            tools_with_parsers=tools_with_parsers,
+            max_steps=max_steps,
+            tool_prompt_template=tool_prompt_template,
+        )
+
+        self.benchmark_directory = benchmark_directory
+        self.parser = XMLParser(fields=["think", "answer", "tool"])
+        self._fields = [
+            ("think", ["think"]),
+            ("answer", ["answer"]),
+            ("tool", ["tool"]),
+        ]
+
+    def parse(self, text: str, strip: bool = True):
+        return self.parser.parse(text, strip=strip)
+
+    def get_dataset(
+        self,
+        max_size: int = 1024,
+    ) -> Dataset:
+        dataset = create_r1_vstar_tool_use_dataset(
+            benchmark_directory=self.benchmark_directory,
+            max_size=max_size,
+        )
+        dataset = self.inject_system_prompt(dataset)
+        dataset = preprocess_r1_dataset(dataset)
+        return dataset

--- a/src/r1_vlm/environments/vstar_eval/vstar_eval_env.py
+++ b/src/r1_vlm/environments/vstar_eval/vstar_eval_env.py
@@ -48,6 +48,11 @@ class SimpleVStarEvalEnv(SimpleVisionEnv):
         dataset = preprocess_r1_dataset(dataset)
         return dataset
 
+    def get_rubric(self):
+        raise NotImplementedError(
+            "get_rubric is not implemented for SimpleVStarEvalEnv because the env is used for evaluation only"
+        )
+
 class VStarToolEnv(ToolVisionEnv):
     def __init__(
         self,

--- a/src/r1_vlm/environments/vstar_eval/vstar_eval_env.py
+++ b/src/r1_vlm/environments/vstar_eval/vstar_eval_env.py
@@ -73,7 +73,7 @@ class VStarToolEnv(ToolVisionEnv):
 
     def get_dataset(
         self,
-        max_size: int = 1024,
+        max_size: int | None = None,
     ) -> Dataset:
         dataset = create_r1_vstar_tool_use_dataset(
             benchmark_directory=self.benchmark_directory,

--- a/src/r1_vlm/eval/eval_vstar.py
+++ b/src/r1_vlm/eval/eval_vstar.py
@@ -1,0 +1,136 @@
+import os
+import json
+import argparse
+from PIL import Image
+from typing import Any
+from transformers import AutoProcessor
+from datasets import load_dataset, Dataset
+from vllm import LLM, SamplingParams
+from vllm.sampling_params import GuidedDecodingParams
+from r1_vlm.datasets.utils import IMAGE_PLACEHOLDER
+from r1_vlm.environments.simple_text_vqa_env.simple_text_vqa_env import (
+    SimpleTextVQAEnv,
+    normalize_answer,
+)
+
+from tqdm import tqdm
+
+# evaluating a VLM on V* Bench: craigwu/vstar_bench on HF
+# the evaluation is done with the multi-choice setting, where the answe could only be one of the options: A, B, C, or D
+
+def generate_simple_vstar_messages(example: dict, benchmark_directory: str) -> dict[str, Any]:
+    question = example["text"]
+    image_path = os.path.join(benchmark_directory, example["image"])
+    image = Image.open(image_path)
+    # resize the image's width to 1024
+    # image = image.resize((1024, int(image.height * 1024 / image.width)))
+
+    r1_messages: list[dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "You are a helpful assistant.",
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": question},
+            ],
+        },
+    ]
+    return {
+        "messages": r1_messages,
+        "image": image,
+        "category": example["category"],
+        "label": example["label"],
+        "question_id": example["question_id"],
+    }
+
+def generate_completions(args: argparse.Namespace, dataset: Dataset):
+    vlm = LLM(
+        model=args.model_path,
+        gpu_memory_utilization=0.9,
+        dtype="bfloat16",
+        tensor_parallel_size=args.tensor_parallel_size,
+        enable_prefix_caching=True,
+        limit_mm_per_prompt={"image": args.limit_image_per_prompt, "video": 0},
+    )
+    processor = AutoProcessor.from_pretrained(args.model_path)
+    env = SimpleTextVQAEnv(processing_class=processor)
+
+    sampling_params = SamplingParams(
+        temperature=args.temperature,
+        max_tokens=args.max_tokens,
+        guided_decoding=GuidedDecodingParams(
+            choice=["A", "B", "C", "D"],
+        ),
+    )
+
+    batch_size = args.batch_size
+    batches = []
+
+    for example in dataset:
+        processed_example = generate_simple_vstar_messages(example, args.benchmark_directory)
+        if len(batches) == 0:
+            batches.append([processed_example])
+        elif len(batches[-1]) < batch_size:
+            batches[-1].append(processed_example)
+        else:
+            batches.append([processed_example])
+
+    results = []
+    for batch in tqdm(batches):
+        conversations, texts, processed_batch, vllm_inputs = env.prepare_data(
+            inputs=batch, processing_class=processor
+        )
+
+        completion_ids = env.generate(
+            conversations=conversations,
+            vlm_inputs=vllm_inputs,
+            vlm=vlm,
+            sampling_params=sampling_params,
+        )
+
+        generated_texts = processor.batch_decode(
+            completion_ids["ids"],
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )
+
+        for example, model_answer in zip(batch, generated_texts):
+            correct_answers = example["label"]
+
+            result = {
+                "question_id": example["question_id"],
+                "gt_answers": correct_answers,
+                "model_answer": model_answer,
+                "correct": correct_answers == model_answer,
+                "category": example["category"],
+            }
+            results.append(result)
+            with open(args.output_path, "a") as f:
+                f.write(json.dumps(result) + "\n")
+    return results
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, default="Qwen/Qwen2.5-VL-7B-Instruct")
+    parser.add_argument("--benchmark_directory", type=str, default="/millcreek/data/vstar_bench")
+    parser.add_argument("--limit_image_per_prompt", type=int, default=1)
+    parser.add_argument("--temperature", type=float, default=0.1)
+    parser.add_argument("--max_tokens", type=int, default=2048)
+    parser.add_argument("--batch_size", type=int, default=12)
+    parser.add_argument("--tensor_parallel_size", type=int, default=4)
+    parser.add_argument("--output_path", type=str, default="vstar_results.jsonl")
+    args = parser.parse_args()
+
+    eval_dataset = load_dataset("craigwu/vstar_bench", split="test")
+    results = generate_completions(args, eval_dataset)
+    accuracy = sum([1 if result["correct"] else 0 for result in results]) / len(results)
+    print(f"Accuracy: {accuracy * 100:.2f}%")


### PR DESCRIPTION
This PR adds the corresponding datasets and environments of evaluating GRPO-trained VLMs with zoom-in tool-use capabilities on V* bench and HR-bench. 
To evaluate models on V* bench, simply run:
```bash
uv run python src/r1_vlm/environments/vstar_eval/eval_vstar.py --output_path <path-to-output-file> --max_size None --model_path <path-to-your-model>
```
To evaluate models on HR-bench, run:
```bash
python src/r1_vlm/environments/hr_bench_eval/eval_hrbench.py --output_path <path-to-output-file> --split 4k --batch_size 2 --output_path --model_path <path-to-your-model>
```

To evaluate models for the 8k split on HR-bench, simply replace `4k` with `8k` and you might need to change `batch_size` to 1 to prevent OOM errors.